### PR TITLE
generate DECLT via peephole

### DIFF
--- a/gcc/config/csky/abiv2_csky.md
+++ b/gcc/config/csky/abiv2_csky.md
@@ -3196,22 +3196,13 @@
 )
 
 (define_insn "*cskyv2_tstsi2"
-  [(set (reg:CC CSKY_CC_REGNUM) (ne:CC (and:SI (match_operand:SI 0 "register_operand"      "b,r,a,r")
-                                               (match_operand:SI 1 "csky_arith_Uf_operand" "b,r,Ub,Ub"))
+  [(set (reg:CC CSKY_CC_REGNUM) (ne:CC (and:SI (match_operand:SI 0 "register_operand" "b,r")
+                                               (match_operand:SI 1 "register_operand" "b,r"))
                                        (const_int 0)))]
   "CSKY_ISA_FEATURE(E2)"
-  "*{
-     switch (which_alternative)
-       {
-       case 0:
-       case 1: return \"tst\t%0, %1\";
-       case 2:
-       case 3: return \"btsti\t%0, %P1\";
-       default: gcc_unreachable ();
-       }
-  }"
-  [(set_attr "length" "2,4,2,4")
-   (set_attr "type" "cmp,cmp,cmp,cmp")]
+  "tst\t%0, %1"
+  [(set_attr "length" "2,4")
+   (set_attr "type" "cmp,cmp")]
 )
 
 
@@ -4295,34 +4286,15 @@
                       (pc)))]
 )
 
-;; optimize if and only if the immediate is power of 2
-;;   and	rz, rx, imm
-;;   cmpnei	rz, 0
-;; to
-;;   btsti	rx, log2(imm)
-(define_peephole2
+(define_peephole
   [(set (match_operand:SI 0 "register_operand" "")
-        (and:SI (match_operand:SI 1 "register_operand" "")
-                (match_operand:SI 2 "csky_literal_Ub_operand" "")))
-   (set (reg:CC CSKY_CC_REGNUM) (ne:CC (match_dup 0)
-                                       (const_int 0)))]
+        (plus:SI (match_operand:SI 1 "register_operand" "")
+                 (match_operand:SI 2 "csky_literal_Uh_operand" "")))
+   (set (reg:CC CSKY_CC_REGNUM)
+        (lt:CC (match_dup 0)
+               (const_int 0)))]
    "CSKY_ISA_FEATURE(E2)"
-   [(set (reg:CC CSKY_CC_REGNUM) (ne:CC (and:SI (match_dup 1)
-                                                (match_dup 2))
-                                        (const_int 0)))]
-)
-(define_peephole2
-  [(set (match_operand:SI 0 "register_operand" "")
-        (match_operand:SI 1 "csky_literal_Ub_operand" ""))
-   (set (match_operand:SI 2 "register_operand" "")
-        (and:SI (match_operand:SI 3 "register_operand" "")
-                (match_dup 0)))
-   (set (reg:CC CSKY_CC_REGNUM) (ne:CC (match_dup 2)
-                                       (const_int 0)))]
-   "CSKY_ISA_FEATURE(E2)"
-   [(set (reg:CC CSKY_CC_REGNUM) (ne:CC (and:SI (match_dup 3)
-                                                (match_dup 1))
-                                        (const_int 0)))]
+   "declt\t%0, %1, %n2"
 )
 
 (define_expand "doloop_begin"

--- a/gcc/config/csky/abiv2_csky_predicates.md
+++ b/gcc/config/csky/abiv2_csky_predicates.md
@@ -127,15 +127,6 @@
     return 0;
   })
 
-(define_predicate "csky_literal_Ub_operand"
-  (match_code "const_int")
-  {
-    if (CONST_INT_P (op) && CSKY_CONST_OK_FOR_Ub (INTVAL(op)))
-      return 1;
-
-    return 0;
-  })
-
 (define_predicate "csky_arith_Uu_operand"
   (match_code "reg,subreg,const_int")
   {
@@ -179,6 +170,15 @@
   (match_code "const_int")
   {
     if (CONST_INT_P (op) && CSKY_CONST_OK_FOR_Uk (INTVAL(op)))
+      return 1;
+
+    return 0;
+  })
+
+(define_predicate "csky_literal_Uh_operand"
+  (match_code "const_int")
+  {
+    if (CONST_INT_P (op) && CSKY_CONST_OK_FOR_Uh (INTVAL(op)))
       return 1;
 
     return 0;

--- a/gcc/config/csky/abiv2_csky_predicates.md
+++ b/gcc/config/csky/abiv2_csky_predicates.md
@@ -127,6 +127,15 @@
     return 0;
   })
 
+(define_predicate "csky_literal_Ub_operand"
+  (match_code "const_int")
+  {
+    if (CONST_INT_P (op) && CSKY_CONST_OK_FOR_Ub (INTVAL(op)))
+      return 1;
+
+    return 0;
+  })
+
 (define_predicate "csky_arith_Uu_operand"
   (match_code "reg,subreg,const_int")
   {


### PR DESCRIPTION
I put the pattern 
(set (plus imm))
(set CC (lt))
in a peephole than a define_insn,

is that the latter "(set CC (lt ))" might be merged into following "if-then-else", which leads the pattern be corrupted.