### PR TITLE
several optimizations

### DIFF
--- a/gcc/config/csky/abiv2_csky.md
+++ b/gcc/config/csky/abiv2_csky.md
@@ -1007,8 +1007,6 @@
    (set_attr "length" "2,2,4,2,2,4,2,2,4")]
 )
 
-;; TODO:define insn for addh.s32
-
 (define_insn "*dspv2_addhusi3"
   [(set (match_operand:SI          0 "register_operand"  "=r")
         (udiv:SI (plus:SI (match_operand:SI 1 "register_operand"  "%r")
@@ -1019,6 +1017,16 @@
   [(set_attr "length" "4")]
 )
 
+(define_insn "*dspv2_addhsi3"
+  [(set (match_operand:SI                  0 "register_operand"  "=r")
+        (div:SI (plus:SI (match_operand:SI 1 "register_operand"  "%r")
+                         (match_operand:SI 2 "register_operand"  "r"))
+                (const_int 2)))]
+  "CSKY_ISA_FEATURE(dspv2)"
+  "addh.s32\t%0, %1, %2"
+  [(set_attr "length" "4")]
+)
+
 (define_insn "*dspv2_addhusi3_2"
   [(set (match_operand:SI          0 "register_operand"  "=r")
         (lshiftrt:SI (plus:SI (match_operand:SI 1 "register_operand"  "%r")
@@ -1026,6 +1034,16 @@
                 (const_int 1)))]
   "CSKY_ISA_FEATURE(dspv2)"
   "addh.u32\t%0, %1, %2"
+  [(set_attr "length" "4")]
+)
+
+(define_insn "*dspv2_addhsi3_2"
+  [(set (match_operand:SI                       0 "register_operand"  "=r")
+        (ashiftrt:SI (plus:SI (match_operand:SI 1 "register_operand"  "%r")
+                              (match_operand:SI 2 "register_operand"  "r"))
+                     (const_int 1)))]
+  "CSKY_ISA_FEATURE(dspv2)"
+  "addh.s32\t%0, %1, %2"
   [(set_attr "length" "4")]
 )
 
@@ -1205,9 +1223,7 @@
    (set_attr "length" "2,2,4,2,2,4,2,2,4")]
 )
 
-;; TODO:define insn for subh.s32
-
-(define_insn "*dspv2_addhusi3"
+(define_insn "*dspv2_subhusi3"
   [(set (match_operand:SI          0 "register_operand"  "=r")
         (udiv:SI (minus:SI (match_operand:SI 1 "register_operand"  "r")
                            (match_operand:SI 2 "register_operand"  "r"))
@@ -1217,13 +1233,33 @@
   [(set_attr "length" "4")]
 )
 
-(define_insn "*dspv2_addhusi3_2"
+(define_insn "*dspv2_subhsi3"
+  [(set (match_operand:SI                    0 "register_operand"  "=r")
+        (udiv:SI (minus:SI (match_operand:SI 1 "register_operand"  "r")
+                           (match_operand:SI 2 "register_operand"  "r"))
+                 (const_int 2)))]
+  "CSKY_ISA_FEATURE(dspv2)"
+  "subh.s32\t%0, %1, %2"
+  [(set_attr "length" "4")]
+)
+
+(define_insn "*dspv2_subhusi3_2"
   [(set (match_operand:SI          0 "register_operand"  "=r")
         (lshiftrt:SI (minus:SI (match_operand:SI 1 "register_operand"  "%r")
                                (match_operand:SI 2 "register_operand"  "r"))
                      (const_int 1)))]
   "CSKY_ISA_FEATURE(dspv2)"
   "subh.u32\t%0, %1, %2"
+  [(set_attr "length" "4")]
+)
+
+(define_insn "*dspv2_subhsi3_2"
+  [(set (match_operand:SI                        0 "register_operand"  "=r")
+        (ashiftrt:SI (minus:SI (match_operand:SI 1 "register_operand"  "%r")
+                               (match_operand:SI 2 "register_operand"  "r"))
+                     (const_int 1)))]
+  "CSKY_ISA_FEATURE(dspv2)"
+  "subh.s32\t%0, %1, %2"
   [(set_attr "length" "4")]
 )
 
@@ -4208,6 +4244,15 @@
    (set_attr "isa"    "def,2e3")]
 )
 
+(define_insn "bswaphi2"
+  [(set (match_operand:SI           0 "register_operand" "=b,r")
+        (bswap:SI (match_operand:SI 1 "register_operand" "b, r")))]
+  "CSKY_ISA_FEATURE(E2)"
+  "revh\t%0, %1"
+  [(set_attr "length" "2,4")
+   (set_attr "isa"    "def,2e3")]
+)
+
 ;; ------------------------------------------------------------------------
 ;; max & min insns
 ;; ------------------------------------------------------------------------
@@ -4284,6 +4329,28 @@
         (if_then_else (eq (reg:CC CSKY_CC_REGNUM) (const_int 0))
                       (label_ref (match_dup 4))
                       (pc)))]
+)
+
+(define_peephole
+  [(set (match_operand:SI 0 "register_operand" "")
+        (plus:SI (match_operand:SI 1 "register_operand" "")
+                 (match_operand:SI 2 "csky_literal_Uh_operand" "")))
+   (set (reg:CC CSKY_CC_REGNUM)
+        (lt:CC (match_dup 0)
+               (const_int 0)))]
+   "CSKY_ISA_FEATURE(E2)"
+   "declt\t%0, %1, %n2"
+)
+
+(define_peephole
+  [(set (match_operand:SI 0 "register_operand" "")
+        (plus:SI (match_operand:SI 1 "register_operand" "")
+                 (match_operand:SI 2 "csky_literal_Uh_operand" "")))
+   (set (reg:CC CSKY_CC_REGNUM)
+        (ne:CC (match_dup 0)
+               (const_int 0)))]
+   "CSKY_ISA_FEATURE(E2)"
+   "decne\t%0, %1, %n2"
 )
 
 (define_expand "doloop_begin"
@@ -4383,10 +4450,4 @@
          (const_int 12)))])
 
 ;;TODO emit decgt.
-;;TODO emit declt.
-;;TODO emit decne.
-;;TODO emit dect.
 ;;TODO emit asrc.
-;;TODO emit brev.
-;;TODO emit ixd.
-;;TODO emit revb.

--- a/gcc/config/csky/abiv2_csky_predicates.md
+++ b/gcc/config/csky/abiv2_csky_predicates.md
@@ -175,6 +175,15 @@
     return 0;
   })
 
+(define_predicate "csky_literal_Uh_operand"
+  (match_code "const_int")
+  {
+    if (CONST_INT_P (op) && CSKY_CONST_OK_FOR_Uh (INTVAL(op)))
+      return 1;
+
+    return 0;
+  })
+
 ;; Nonzero if OP is a register or constant value of 1
 
 (define_predicate "csky_arith_int1_operand"


### PR DESCRIPTION
1. generate DSPV2 instructions, addh.s32/subh.s32

2. generate "bswaphi2" -> "revh"

3. generate declt/decne, they can only be generated via peephole,
for define_insn, declt can be generated via neither combined RTX pattern, nor match_parallel.

